### PR TITLE
Implement token object for sls_adf

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,3 @@
 plugins:
   bundler-audit:
     enabled: true
-  rubocop:
-    enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,18 @@
 AllCops:
   TargetRubyVersion: 2.4
+
+Metrics/BlockLength:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Metrics/LineLength:
+  Max: 120
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Layout/DotPosition:
+  EnforcedStyle: trailing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,11 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
     dotenv (2.2.1)
@@ -24,10 +28,12 @@ GEM
     graphql-client (0.12.2)
       activesupport (>= 3.0, < 6.0)
       graphql (~> 1.6)
+    hashdiff (0.3.7)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     minitest (5.10.3)
+    public_suffix (3.0.1)
     rake (10.5.0)
     rdoc (6.0.0)
     rspec (3.7.0)
@@ -43,6 +49,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
+    safe_yaml (1.0.4)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -53,6 +60,10 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
+    webmock (3.1.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -65,6 +76,7 @@ DEPENDENCIES
   rspec (~> 3.0)
   simplecov
   sls_adf!
+  webmock
 
 BUNDLED WITH
    1.16.0

--- a/lib/sls_adf.rb
+++ b/lib/sls_adf.rb
@@ -2,5 +2,6 @@
 
 require 'sls_adf/version'
 require 'sls_adf/configuration'
+require 'sls_adf/util'
 
 module SlsAdf; end

--- a/lib/sls_adf/util.rb
+++ b/lib/sls_adf/util.rb
@@ -1,8 +1,12 @@
+# frozen_string_literal: true
+
 require 'sls_adf/util/token'
 
-module SlsAdf::Util
-  COMMON_HEADERS = {
-    'Accept' => 'application/json',
-    'Content-Type' => 'application/json'
-  }.freeze
+module SlsAdf
+  module Util
+    COMMON_HEADERS = {
+      'Accept' => 'application/json',
+      'Content-Type' => 'application/json'
+    }.freeze
+  end
 end

--- a/lib/sls_adf/util.rb
+++ b/lib/sls_adf/util.rb
@@ -1,0 +1,8 @@
+require 'sls_adf/util/token'
+
+module SlsAdf::Util
+  COMMON_HEADERS = {
+    'Accept' => 'application/json',
+    'Content-Type' => 'application/json'
+  }.freeze
+end

--- a/lib/sls_adf/util/token.rb
+++ b/lib/sls_adf/util/token.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+require 'typhoeus'
+require 'json'
+
+module SlsAdf::Util
+  # Token used to store the ADF API's client credentials token.
+  # This is used by +SlsAdf::Util::Adapter+ to make API calls to ADF.
+  #
+  # The token will be an empty string if:
+  #   i) The get_token call is unsuccessful (HTTP status code not 200).
+  #   ii) The credentials are invalid.
+  class Token
+    class << self
+      # Returns the token. If no token exists, an API call is made to get the token.
+      #
+      # @return [String] The ADF API token.
+      def token
+        @@token ||= get_token
+      end
+
+      # Forces an API call to get the token.
+      #
+      # @return [String] The ADF API token.
+      def refresh_token
+        @@token = get_token
+      end
+
+      private
+
+      # Returns the token after making an API call to get the token.
+      # An empty string is returned if:
+      #   i) The call is unsuccessful (HTTP status code not 200).
+      #   ii) The credentials are invalid.
+      #
+      # @return [String] The responded token, or an empty string.
+      def get_token
+        response = get_token_call
+        response.code == 200 ? parse_response(response.body) : ''
+      end
+
+      # Returns the response for a POST token API call.
+      #
+      # @return [Typhoeus::Response] The response object.
+      def get_token_call
+        Typhoeus.post(get_token_url, headers: COMMON_HEADERS, body: body)
+      end
+
+      # Attempts to parse the string in Json to obtain the token.
+      #
+      # @param [String] body String to be parsed
+      # @return [String] The parsed token, or blank if an error occurs.
+      def parse_response(body)
+        token = JSON.parse(body)['data']['token']
+        token ? token : ''
+      rescue JSON::ParserError
+        ''
+      end
+
+      def body
+        JSON.dump(
+          clientId: client_id,
+          clientSecret: client_secret,
+          grantType: 'client_credentials',
+          scope: 'all'
+        )
+      end
+
+      def client_id
+        SlsAdf.configuration.client_id
+      end
+
+      def client_secret
+        SlsAdf.configuration.client_secret
+      end
+
+      def get_token_url
+        SlsAdf.configuration.get_token_url
+      end
+    end
+  end
+end

--- a/lib/sls_adf/util/token.rb
+++ b/lib/sls_adf/util/token.rb
@@ -1,80 +1,83 @@
 # frozen_string_literal: true
+
 require 'typhoeus'
 require 'json'
 
-module SlsAdf::Util
-  # Token used to store the ADF API's client credentials token.
-  # This is used by +SlsAdf::Util::Adapter+ to make API calls to ADF.
-  #
-  # The token will be an empty string if:
-  #   i) The get_token call is unsuccessful (HTTP status code not 200).
-  #   ii) The credentials are invalid.
-  class Token
-    class << self
-      # Returns the token. If no token exists, an API call is made to get the token.
-      #
-      # @return [String] The ADF API token.
-      def token
-        @@token ||= get_token
-      end
+module SlsAdf
+  module Util
+    # Token used to store the ADF API's client credentials token.
+    # This is used by +SlsAdf::Util::Adapter+ to make API calls to ADF.
+    #
+    # The token will be an empty string if:
+    #   i) The get_token call is unsuccessful (HTTP status code not 200).
+    #   ii) The credentials are invalid.
+    class Token
+      class << self
+        # Returns the token. If no token exists, an API call is made to get the token.
+        #
+        # @return [String] The ADF API token.
+        def token
+          @token ||= get_token
+        end
 
-      # Forces an API call to get the token.
-      #
-      # @return [String] The ADF API token.
-      def refresh_token
-        @@token = get_token
-      end
+        # Forces an API call to get the token.
+        #
+        # @return [String] The ADF API token.
+        def refresh_token
+          @token = get_token
+        end
 
-      private
+        private
 
-      # Returns the token after making an API call to get the token.
-      # An empty string is returned if:
-      #   i) The call is unsuccessful (HTTP status code not 200).
-      #   ii) The credentials are invalid.
-      #
-      # @return [String] The responded token, or an empty string.
-      def get_token
-        response = get_token_call
-        response.code == 200 ? parse_response(response.body) : ''
-      end
+        # Returns the token after making an API call to get the token.
+        # An empty string is returned if:
+        #   i) The call is unsuccessful (HTTP status code not 200).
+        #   ii) The credentials are invalid.
+        #
+        # @return [String] The responded token, or an empty string.
+        def get_token # rubocop:disable Style/AccessorMethodName
+          response = get_token_call
+          response.code == 200 ? parse_response(response.body) : ''
+        end
 
-      # Returns the response for a POST token API call.
-      #
-      # @return [Typhoeus::Response] The response object.
-      def get_token_call
-        Typhoeus.post(get_token_url, headers: COMMON_HEADERS, body: body)
-      end
+        # Returns the response for a POST token API call.
+        #
+        # @return [Typhoeus::Response] The response object.
+        def get_token_call # rubocop:disable Style/AccessorMethodName
+          Typhoeus.post(get_token_url, headers: COMMON_HEADERS, body: body)
+        end
 
-      # Attempts to parse the string in Json to obtain the token.
-      #
-      # @param [String] body String to be parsed
-      # @return [String] The parsed token, or blank if an error occurs.
-      def parse_response(body)
-        token = JSON.parse(body)['data']['token']
-        token ? token : ''
-      rescue JSON::ParserError
-        ''
-      end
+        # Attempts to parse the string in Json to obtain the token.
+        #
+        # @param [String] body String to be parsed
+        # @return [String] The parsed token, or blank if an error occurs.
+        def parse_response(body)
+          token = JSON.parse(body)['data']['token']
+          token ? token : ''
+        rescue JSON::ParserError
+          ''
+        end
 
-      def body
-        JSON.dump(
-          clientId: client_id,
-          clientSecret: client_secret,
-          grantType: 'client_credentials',
-          scope: 'all'
-        )
-      end
+        def body
+          JSON.dump(
+            clientId: client_id,
+            clientSecret: client_secret,
+            grantType: 'client_credentials',
+            scope: 'all'
+          )
+        end
 
-      def client_id
-        SlsAdf.configuration.client_id
-      end
+        def client_id
+          SlsAdf.configuration.client_id
+        end
 
-      def client_secret
-        SlsAdf.configuration.client_secret
-      end
+        def client_secret
+          SlsAdf.configuration.client_secret
+        end
 
-      def get_token_url
-        SlsAdf.configuration.get_token_url
+        def get_token_url # rubocop:disable Style/AccessorMethodName
+          SlsAdf.configuration.get_token_url
+        end
       end
     end
   end

--- a/sls_adf.gemspec
+++ b/sls_adf.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'webmock'
 end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 if ENV['CI']
   require 'simplecov'
   SimpleCov.start

--- a/spec/lib/util/token_spec.rb
+++ b/spec/lib/util/token_spec.rb
@@ -1,0 +1,95 @@
+RSpec.describe SlsAdf::Util::Token do
+  def expected_response_body
+    JSON.dump(data: { token: SlsAdf::CLIENT_TOKEN })
+  end
+
+  def expected_request_body
+    { 'clientId' => SlsAdf.configuration.client_id,
+      'clientSecret' => SlsAdf.configuration.client_secret,
+      'grantType' => 'client_credentials',
+      'scope' => 'all' }
+  end
+
+  describe '.token' do
+    let!(:stub) do
+      stub_request(:post, SlsAdf.configuration.get_token_url).
+        to_return(status: 200, body: expected_response_body)
+    end
+    subject { SlsAdf::Util::Token.token }
+
+    it 'returns the correct token' do
+      expect(subject).to eq SlsAdf::CLIENT_TOKEN
+      expect(stub).to have_been_requested
+    end
+
+    context 'when token has been pre-loaded' do
+      before { subject }
+      it 'does not make another API call to load the token' do
+        # Clears stub and request history
+        WebMock.reset!
+        # Subject is not used as it doesn't invoke the actual object's method again.
+        SlsAdf::Util::Token.token
+        expect(a_request(:any, SlsAdf.configuration.get_token_url)).
+          not_to have_been_made
+      end
+    end
+  end
+
+  describe '.refresh_token' do
+    let!(:stub) do
+      stub_request(:post, SlsAdf.configuration.get_token_url).
+        to_return(status: http_response_code, body: expected_response_body)
+    end
+    let(:http_response_code) { 200 }
+    subject { SlsAdf::Util::Token.refresh_token }
+
+    it 'returns the correct token' do
+      expect(subject).to eq SlsAdf::CLIENT_TOKEN
+      expect(stub).to have_been_requested
+    end
+
+    it 'makes the right API call to the get token url' do
+      stub =
+        stub_request(:post, SlsAdf.configuration.get_token_url).
+          with(
+            headers: { 'Content-Type' => 'application/json' },
+            body: expected_request_body
+          ).
+          to_return(status: 200, body: expected_response_body)
+      subject
+      expect(stub).to have_been_requested
+    end
+
+    context 'when token has been preloaded' do
+      before { subject }
+      it 'makes another API call to load the token' do
+        # Clears stub and request history
+        WebMock.reset!
+
+        new_stub = stub_request(:post, SlsAdf.configuration.get_token_url).
+                     to_return(status: 200, body: expected_response_body)
+        # Subject is not used as it doesn't invoke the actual object's method again.
+        SlsAdf::Util::Token.refresh_token
+        expect(new_stub).to have_been_requested
+      end
+    end
+
+    context 'when API response is malformed' do
+      let!(:stub) do
+        stub_request(:post, SlsAdf.configuration.get_token_url).
+          to_return(status: 200, body: '400 Error')
+      end
+
+      it 'returns an empty string as the token' do
+        expect(subject).to eq('')
+      end
+    end
+
+    context 'when API response does not have http status code 200' do
+      let(:http_response_code) { 400 }
+      it 'returns an empty string as the token' do
+        expect(subject).to eq('')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'coverage_helper'
 
 require 'bundler/setup'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'coverage_helper'
 
 require 'bundler/setup'
+require 'webmock/rspec'
 require 'sls_adf'
 
 # Load all files within the support folder

--- a/spec/support/sls_adf_helper.rb
+++ b/spec/support/sls_adf_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This helper helps to set the initial values for the gem, and exposes these
 # values as variables for use in rspec.
 


### PR DESCRIPTION
- Token uses typhoeus to make api calls to get token
- Token allows for two methods, #token and #refresh_token to return the token
- webmock is used in testing to stub http requests