### PR TITLE
Namespace ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ you may:
 
 Key Commands:
  - `bin/setup`: Install dependencies and copy `.env` file.
- - `bin/console`: Run an interactive prompt (requires configuration on .`env` file)
+ - `bin/console`: Run an interactive prompt (requires configuration on .`env` file).
  - `rake spec` or `bundle exec rspec`: Run tests.
- - `rake sls_adf:update_schema`: Update the SLS ADF GraphQL schema.
+ - `rake sls_adf:update_schema`: Update the SLS ADF GraphQL schema (requires configuration on .`env` file).
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -27,10 +27,10 @@ namespace :sls_adf do
 
     Dotenv.load
     SlsAdf.configure do |c|
-      c.graphql_url = ENV.fetch('GRAPHQL_URL')
-      c.get_token_url = ENV.fetch('GET_TOKEN_URL')
-      c.client_id = ENV.fetch('CLIENT_ID')
-      c.client_secret = ENV.fetch('CLIENT_SECRET')
+      c.graphql_url = ENV.fetch('SLS_ADF_GRAPHQL_URL')
+      c.get_token_url = ENV.fetch('SLS_ADF_GET_TOKEN_URL')
+      c.client_id = ENV.fetch('SLS_ADF_CLIENT_ID')
+      c.client_secret = ENV.fetch('SLS_ADF_CLIENT_SECRET')
     end
 
     schema_location = File.join(File.dirname(__FILE__), 'lib/sls_adf/schema/schema.json')

--- a/bin/console
+++ b/bin/console
@@ -8,10 +8,10 @@ Dotenv.load
 # Configure Gem
 require 'sls_adf'
 SlsAdf.configure do |config|
-  config.graphql_url = ENV['GRAPHQL_URL']
-  config.get_token_url = ENV['GET_TOKEN_URL']
-  config.client_id = ENV['CLIENT_ID']
-  config.client_secret = ENV['CLIENT_SECRET']
+  config.graphql_url = ENV['SLS_ADF_GRAPHQL_URL']
+  config.get_token_url = ENV['SLS_ADF_GET_TOKEN_URL']
+  config.client_id = ENV['SLS_ADF_CLIENT_ID']
+  config.client_secret = ENV['SLS_ADF_CLIENT_SECRET']
 end
 
 # (If you use this, don't forget to add pry to your Gemfile!)


### PR DESCRIPTION
This is to achieve parity with how it might be used in a project: projects consuming this API will likely have many other ENV variables and variables for this project might have to be namespaced. `CLIENT_ID` etc are too generic.